### PR TITLE
Fix semantic bugs that silently produce incorrect results

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,168 @@
+# LPF Known Issues
+
+> 작성일: 2026-02-17
+> 대상: 무당벌레 날개 색상 패턴 형성 시뮬레이션 (반응-확산 PDE 프레임워크)
+
+전반적인 아키텍처 설계(Factory 패턴, Strategy 패턴, 다중 백엔드 지원)는 잘 되어 있으나,
+코드 품질 면에서 상당수의 버그와 개선점이 발견되었습니다.
+
+---
+
+## 1. CRITICAL 버그 (런타임 크래시)
+
+- [x] **1-1. `MaxHistogramRootMeanSquareError` 잘못된 상속**
+  - **위치:** `lpf/objectives/histrmse.py:84`
+  - **내용:** `EachHistogramRootMeanSquareError` 대신 `Objective`를 상속하여, `super().compute()`가 `NotImplementedError`를 발생시킵니다.
+
+- [x] **1-2. DOPRI5 solver가 NumPy/CuPy/JAX에서 작동 불가**
+  - **위치:** `lpf/solvers/dopri5solver.py:117`
+  - **내용:** `model.am.sqrt()`, `model.am.mean()`은 `TorchModule`에만 정의되어 있습니다. 다른 백엔드에서는 `AttributeError`가 발생합니다.
+
+- [x] **1-3. AdaptiveRK45 solver가 NumPy 전용**
+  - **위치:** `lpf/solvers/adaptiverk45solver.py:63-97`
+  - **내용:** `np.zeros`, `np.sum`, `np.abs`, `np.max` 등을 하드코딩하여 GPU 백엔드(CuPy, PyTorch, JAX)에서 사용 불가합니다.
+
+- [x] **1-4. Adaptive solver의 시간 적분 오류**
+  - **위치:** `lpf/solvers/dopri5solver.py`, `lpf/solvers/adaptiverk45solver.py`
+  - **내용:** adaptive sub-step이 `dt`보다 작을 때 한 번만 sub-step을 수행하지만, 외부 루프는 full `dt`만큼 시간을 전진시킵니다. 시간 불일치로 인해 적분 결과가 부정확합니다.
+
+- [x] **1-5. `SolverFactory`에서 `adaptive_rk45`가 잘못된 solver 생성**
+  - **위치:** `lpf/solvers/solverfactory.py:42`
+  - **내용:** `"rk45" in "adaptiverk45"`가 `True`이므로, `AdaptiveRKF45Solver` 대신 `RungeKuttaSolver`(고정 스텝 RK4)가 반환됩니다.
+
+- [x] **1-6. `colorize()`에서 numpy 배열 truthiness 오류**
+  - **위치:** `lpf/models/twocomponentmodel.py:240`
+  - **내용:** `if not thr_color:`에서 `thr_color`가 다중 원소 numpy 배열이면 `ValueError` 발생. `if thr_color is None:`이어야 합니다.
+
+- [x] **1-7. `is_early_stopping()`에서 미정의 속성 참조**
+  - **위치:** `lpf/models/twocomponentmodel.py:231-232`
+  - **내용:** `self._f`, `self._g`는 어디에서도 할당되지 않습니다. `reactions()`가 로컬 변수로만 `(f, g)`를 반환하고 인스턴스에 저장하지 않아 `AttributeError`가 발생합니다.
+
+- [x] **1-8. JaxModule의 여러 메서드가 존재하지 않는 API 사용**
+  - **위치:** `lpf/array/module.py:639`, `lpf/array/module.py:659-663`
+  - **내용:** `jnp.generic` 미존재, `clear_memory()`에서 `jax.numpy.clear_backends()` 등 존재하지 않는 메서드 호출
+
+- [x] **1-9. CupyModule `clear_memory()`에서 `self._module.dev` 미존재**
+  - **위치:** `lpf/array/module.py:244`
+  - **내용:** `cupy`에 `dev` 속성이 없어 `AttributeError` 발생.
+
+- [x] **1-10. Converter에서 누락된 쉼표로 문자열 합쳐짐**
+  - **위치:** `lpf/converters/gierermeinhardtconverter.py:16-17`
+  - **내용:** `"nu"` `"u0"` 사이에 쉼표가 없어 Python이 `"nuu0"`으로 연결합니다. 파라미터 이름 리스트가 8개가 아닌 7개가 되어 인덱스 불일치가 발생합니다.
+
+---
+
+## 2. 의미적 버그 (잘못된 결과를 조용히 생산)
+
+- [x] **2-1. `not x` 패턴의 광범위한 오용 (40+ 곳)**
+  - 코드 전반에서 `if not x:`를 `if x is None:` 대신 사용합니다. `x=0`, `x=0.0`, `x=""`, `x=[]` 등 falsy 값이 의도치 않게 기본값으로 대체됩니다.
+  - **영향 받는 주요 위치:**
+    - `twocomponentmodel.py` — `width=0`, `height=0`, `dx=0`, `index=0`, `generation=0`, `fitness=0.0` 등
+    - `solver.py` — `dt=0.0`, `rtol=0.0`, `n_iters=0`
+    - 모든 objective 파일 — `coeff=0`
+    - `evosearch.py:121` — `generation=0`이 빈 문자열로 처리됨
+
+- [x] **2-2. `to_dict()`에서 유효한 0값 누락**
+  - **위치:** `lpf/models/twocomponentmodel.py:352-358`
+  - **내용:** `if index:`, `if generation:`, `if fitness:`가 0값을 건너뜁니다. `index=0`(첫 번째 배치)은 직렬화되지 않습니다.
+
+- [x] **2-3. `float16` 캐스팅으로 인한 잘못된 유효성 검사**
+  - **위치:** `lpf/models/twocomponentmodel.py:219`, `lpf/utils/validation.py:12`
+  - **내용:** float16 최대값은 65504이므로, 65504~inf 범위의 유효한 float32 값이 `inf`로 변환되어 잘못된 상태로 판정됩니다.
+
+- [x] **2-4. `TorchModule.repeat()`의 시맨틱 불일치**
+  - **위치:** `lpf/array/module.py:577-582`
+  - **내용:** `axis=None`일 때 PyTorch의 `repeat`은 NumPy와 다르게 동작합니다. NumPy는 원소 반복 `[a,a,b,b]`, PyTorch는 타일링 `[a,b,a,b]`.
+
+- [x] **2-5. `solver.trj_y` 속성이 잘못된 위치에서 읽음**
+  - **위치:** `lpf/solvers/solver.py:40-41`
+  - **내용:** trajectory는 `self._trj_y`에 저장되지만, property는 `self._model.trj_y`를 반환합니다.
+
+- [x] **2-6. Pattern 저장이 morph 저장에 종속**
+  - **위치:** `lpf/solvers/solver.py:190-202`
+  - **내용:** `dpath_pattern` 체크가 `if dpath_morph:` 블록 안에 중첩되어, morph 없이 pattern만 저장하는 것이 불가능합니다.
+
+---
+
+## 3. YAML 설정 버그
+
+- [ ] `config/evosearch/config_search_ahexaspilota_gpu.yaml:16` — `COLOV_V` 오타 → `COLOR_V`여야 함
+- [ ] `config/evosearch/config_search_all_cpu.yaml:11` — `NUM_INIT_PTS` → `N_INIT_PTS`여야 함 (KeyError 발생)
+- [ ] `config/evosearch/config_search_spectabilis_gpu.yaml:17` — `INIT_POP`이 spectabilis가 아닌 `init_pop_axyridis`를 참조
+- [ ] CPU config 파일들 — `MODEL`, `SOLVER` 키 누락 → KeyError 발생
+
+---
+
+## 4. 이름 짓기 / 복사-붙여넣기 오류
+
+- [ ] `lpf/models/schnakenbergmodel.py:7-11` — docstring이 "Gierer-Meinhardt model"로 잘못 기술
+- [ ] `lpf/models/schnakenbergmodel.py:143` — `# end of class GrayScottModel` (잘못된 클래스명)
+- [ ] `lpf/models/gierermeinhardtmodel.py:143` — `# end of class GrayScottModel` (동일)
+- [ ] `lpf/converters/gierermeinhardtconverter.py:4` — 클래스명이 `GiererMeinhardtModel` (→ `GiererMeinhardtConverter`여야 함)
+- [ ] `lpf/converters/schnakenbergconverter.py:4` — 클래스명이 `SchnakenbergModel` (→ `SchnakenbergConverter`여야 함)
+- [ ] `lpf/objectives/perceptualsimilarity.py:10` — "FrechetInceptionDistance" 오류 메시지 (LPIPS 파일인데)
+- [ ] `lpf/models/diploidy.py:51` — `"maternal_model.parms"` 오타 → `"params"`
+- [ ] 모든 `parse_params` — `@classmethod`인데 첫 파라미터가 `self` (→ `cls`여야 함)
+
+---
+
+## 5. 프로젝트 인프라 문제
+
+- [x] **5-1. 테스트 완전 부재** — 회귀 테스트 추가 완료
+- [ ] **5-2. CI/CD 미설정** — `.github/workflows/`, `.travis.yml`, `tox.ini` 등 자동화된 품질 보증 인프라가 전혀 없습니다.
+- [ ] **5-3. 패키징 문제**
+  - `setup.py`만 사용 (`pyproject.toml` 없음, PEP 517/518 미준수)
+  - `install_requires` 미선언 — `pip install .`로 설치 시 의존성 0개 설치
+  - `package_data` 미설정 — `lpf/data/`의 이미지 파일들이 배포에 포함되지 않음
+  - `__version__` 미정의
+- [ ] **5-4. 의존성 관리**
+  - `requirements.txt`에 버전 핀 없음
+  - PyTorch가 어디에도 의존성으로 선언되지 않음
+  - `moviepy`가 `video.py`에서 import되지만 requirements에 없음
+  - `imghdr` 모듈이 Python 3.13에서 제거됨
+- [ ] **5-5. 쉘 스크립트 다수가 깨져 있음** — `run_evosearch_all.sh` 등이 존재하지 않는 Python 파일을 참조합니다.
+
+---
+
+## 6. 설계/아키텍처 개선점
+
+- [ ] **6-1. `not x` → `x is None`으로 전면 교체 필요** — 가장 광범위한 버그 패턴 (40곳 이상)
+- [ ] **6-2. 모델 간 대량 코드 중복** — `to_dict()`, `parse_params()`, `get_param_bounds()`가 거의 동일. 파라미터 이름/범위를 클래스 속성으로 선언하면 수백 줄 절약 가능.
+- [ ] **6-3. Factory에서 substring 매칭의 취약성** — `if "x" in name:` 패턴을 정확 매칭 딕셔너리로 교체 필요
+- [ ] **6-4. `ConverterFactory`가 Liaw만 지원** — 다른 Converter와 `TwoComponentCrosstalkDiploidModel`이 factory에 미등록
+- [ ] **6-5. VGG16 모델을 4회 중복 로드** (`lpf/objectives/vggperceptualloss.py:29-32`)
+- [ ] **6-6. 진화 탐색의 무제한 캐시 증가** (`lpf/search/evosearch.py:91`) — LRU 캐시 등으로 교체 필요
+- [ ] **6-7. `image.py`에서 하드코딩된 이미지 크기** — resize/crop 좌표가 매직 넘버
+- [ ] **6-8. Optional dependency import 처리 불일치** — `vggperceptualloss.py`, `perceptualsimilarity.py`
+- [ ] **6-9. `rdmodel.py` `y_mesh` setter에 dead code** — `if self._y_mesh is None:` 분기 도달 불가능
+- [ ] **6-10. `AdamsBashforth2Solver`의 stale state** — `_prev_dydt`가 solve() 간에 리셋 안 됨
+- [ ] **6-11. `get_param_bounds()` range 계산 오류** — `range(N, 2 * n_init_pts, 2)` → `range(N, N + 2 * n_init_pts, 2)`
+
+---
+
+## 7. 기타 사소한 이슈
+
+- [ ] `module.py:46,68` — Exception 생성자에 tuple 전달 (f-string 사용해야 함)
+- [ ] `module.py:74,76` — `== None` 대신 `is None` 사용해야 함
+- [ ] `solverfactory.py:1-19` — 주석 처리된 dead code
+- [ ] `solverfactory.py:72` — stiff 문제에 explicit method 추천 (implicit method 필요)
+- [ ] `rungekuttasolver.py:5` — docstring이 "RK45"라고 기술하지만 실제로는 RK4
+- [ ] `adamsbashforth2solver.py:25` — `_prev_t` 저장하지만 어디에서도 읽지 않음
+- [ ] `image.py:94,244,379`, `video.py:13` — 오타: "doest not exists" → "does not exist"
+- [ ] `video.py:3` — deprecated `imghdr` 모듈 사용 (Python 3.13에서 제거됨)
+- [ ] `video.py:17-27` — 비디오 프레임이 정렬되지 않음 (`os.listdir` 결과 미정렬)
+- [ ] `diploidy.py:42` — `id(x) == id(y)` 대신 `x is y` 사용해야 함
+- [ ] `.gitignore` — Django, Flask 등 관련 없는 항목 포함
+- [ ] `search/run_evosearch_succinea.psh` — 잘못된 파일 확장자 `.psh`
+- [ ] 쉘 스크립트에 shebang (`#!/bin/bash`) 누락
+
+---
+
+## 8. 우선순위 요약
+
+| 우선순위 | 카테고리 | 항목 수 | 상태 |
+|---|---|---|---|
+| **P0 - 즉시 수정** | 런타임 크래시 버그 | 10개 | **완료** |
+| **P1 - 높음** | 잘못된 결과 생산 버그 | 6개 | **완료** |
+| **P2 - 중간** | 설정/이름짓기 오류, 인프라 | ~15개 | 미해결 |
+| **P3 - 낮음** | 코드 품질/설계 개선 | ~15개 | 미해결 |

--- a/lpf/array/module.py
+++ b/lpf/array/module.py
@@ -589,9 +589,9 @@ class TorchModule(ArrayModule):
         return arr.clone()
 
     def repeat(self, arr, repeats, axis=None):
-        """Repeat elements of a tensor."""
+        """Repeat elements of a tensor (matching NumPy semantics)."""
         if axis is None:
-            return arr.repeat(repeats)
+            return arr.flatten().repeat_interleave(repeats)
         else:
             return arr.repeat_interleave(repeats, dim=axis)
 

--- a/lpf/models/twocomponentmodel.py
+++ b/lpf/models/twocomponentmodel.py
@@ -42,7 +42,7 @@ class TwoComponentModel(ReactionDiffusionModel):
         # Set initializer.
         self._initializer = initializer
 
-        if n_init_pts:  # used for search
+        if n_init_pts is not None:  # used for search
             self._n_init_pts = n_init_pts
 
         # Set kinetic parameters.
@@ -53,17 +53,17 @@ class TwoComponentModel(ReactionDiffusionModel):
                 self._batch_size = self._params.shape[0]
 
         # Set the size of space (2D grid).
-        if not width:
+        if width is None:
             width = 128
 
-        if not height:
+        if height is None:
             height = 128
 
         self._width = width
         self._height = height
         self.shape = (height, width)
 
-        if not dx:
+        if dx is None:
             dx = 0.1
 
         self._dx = dx
@@ -79,11 +79,11 @@ class TwoComponentModel(ReactionDiffusionModel):
 
         self._thr_color = thr_color
 
-        if not color_u:
+        if color_u is None:
             color_u = (5, 5, 5)
 
-        if not color_v:
-            color_v = (231, 79, 3) 
+        if color_v is None:
+            color_v = (231, 79, 3)
 
         self._color_u = np.array(color_u, dtype=np.uint8)
         self._color_v = np.array(color_v, dtype=np.uint8)
@@ -141,7 +141,7 @@ class TwoComponentModel(ReactionDiffusionModel):
                                             dtype=self._dtype)
         # end of with
 
-        if self._initializer:
+        if self._initializer is not None:
             self._initializer.initialize(self)
 
     def laplacian2d(self, a, dx):
@@ -218,8 +218,8 @@ class TwoComponentModel(ReactionDiffusionModel):
             arr_v = self.v
 
         with self.am:
-            arr_u = arr_u[index, ...].astype(np.float16)
-            arr_v = arr_v[index, ...].astype(np.float16)
+            arr_u = arr_u[index, ...].astype(np.float32)
+            arr_v = arr_v[index, ...].astype(np.float32)
             
             abs_u = self.am.abs(arr_u)
             abs_v = self.am.abs(arr_v)
@@ -323,7 +323,8 @@ class TwoComponentModel(ReactionDiffusionModel):
                    arr_color=None):
 
         ladybird, pattern = self.create_image(index, arr_color)
-        ladybird.save(fpath_morph)
+        if fpath_morph:
+            ladybird.save(fpath_morph)
         if fpath_pattern:
             pattern.save(fpath_pattern)
     
@@ -351,13 +352,13 @@ class TwoComponentModel(ReactionDiffusionModel):
         
         n2v["model"] = self._name
 
-        if index:
+        if index is not None:
             n2v["index"] = index
-            
-        if generation:             
-            n2v["generation"] = generation    
-             
-        if fitness:
+
+        if generation is not None:
+            n2v["generation"] = generation
+
+        if fitness is not None:
             n2v["fitness"] = fitness
        
         # Save parameters for space and colorization.
@@ -369,7 +370,7 @@ class TwoComponentModel(ReactionDiffusionModel):
         n2v["color_v"] = self._color_v.tolist()
        
         # Get the members of initializer: n_init_pts, init_pts, init_states
-        if not initializer and self._initializer:
+        if initializer is None and self._initializer is not None:
             initializer = self._initializer
 
         if initializer is None:
@@ -382,7 +383,7 @@ class TwoComponentModel(ReactionDiffusionModel):
              raise TypeError("initializer should be dict or a subclass of Initializer.")
        
         # Get the members of solver
-        if not solver:
+        if solver is None:
             n2v["solver"] = None
         elif isinstance(solver, dict):
             n2v.update(solver)
@@ -471,7 +472,7 @@ class TwoComponentModel(ReactionDiffusionModel):
         #
         # return init_states
 
-        if not dtype:
+        if dtype is None:
            dtype = np.float64
 
         batch_size = len(model_dicts)
@@ -512,7 +513,7 @@ class TwoComponentModel(ReactionDiffusionModel):
         else:
             raise TypeError("model_dicts should be a sequence of model dictionary or a mappable type like dict.")
 
-        if not dtype:
+        if dtype is None:
            dtype = np.float64
 
         batch_size = len(model_dicts)

--- a/lpf/objectives/colorproportion.py
+++ b/lpf/objectives/colorproportion.py
@@ -9,12 +9,12 @@ from lpf.objectives import Objective
 class EachColorProportion(Objective):
         
     def __init__(self, targets=None, coeff=None, lower=None, upper=None):
-        if not coeff:
+        if coeff is None:
             coeff = 10.0
-            
+
         self._coeff = coeff
-        
-        if targets:
+
+        if targets is not None:
             self._target_colpros = self.get_target_colpros(targets)
         else:
             self._target_colpros = None            
@@ -50,18 +50,18 @@ class EachColorProportion(Objective):
     
     def compute(self, x, targets=None, coeff=None):
         
-        if not self._target_colpros:
-            if not targets:
+        if self._target_colpros is None:
+            if targets is None:
                 err_msg = "targets should be given for compute() " \
                           "if targets are not given for __init__()."
                 raise AttributeError(err_msg)
-                
+
             target_colpros = self.get_target_colpros(targets)
         else:
             target_colpros = self._target_colpros
-            
-                    
-        if not coeff:
+
+
+        if coeff is None:
             coeff = self._coeff
                     
         

--- a/lpf/objectives/histrmse.py
+++ b/lpf/objectives/histrmse.py
@@ -7,13 +7,13 @@ from lpf.objectives import Objective
 
 class EachHistogramRootMeanSquareError(Objective):
         
-    def __init__(self, targets=None, coeff=None):        
-        if not coeff:
+    def __init__(self, targets=None, coeff=None):
+        if coeff is None:
             coeff = 1e-02
-            
+
         self._coeff = coeff
-        
-        if targets:
+
+        if targets is not None:
             self._target_hists = self.get_target_histograms(targets)
         else:
             self._target_hists = None            
@@ -37,18 +37,18 @@ class EachHistogramRootMeanSquareError(Objective):
     
     def compute(self, x, targets=None, coeff=None):
         
-        if not self._target_hists:
-            if not targets:
+        if self._target_hists is None:
+            if targets is None:
                 err_msg = "targets should be given for compute() " \
                           "if targets are not given for __init__()."
                 raise AttributeError(err_msg)
-                
+
             target_hists = self.get_target_histograms(targets)
         else:
             target_hists = self._target_hists
-            
-                    
-        if not coeff:
+
+
+        if coeff is None:
             coeff = self._coeff
                     
         

--- a/lpf/objectives/mse.py
+++ b/lpf/objectives/mse.py
@@ -6,13 +6,13 @@ from lpf.objectives import Objective
 class EachMeanSquareError(Objective):
     
     def __init__(self, coeff=None):
-        if not coeff:
+        if coeff is None:
             coeff = 1e-1
-            
+
         self._coeff = coeff
-                        
-    def compute(self, x, targets, coeff=None):        
-        if not coeff:
+
+    def compute(self, x, targets, coeff=None):
+        if coeff is None:
             coeff = self._coeff
 
         arr_mse = np.zeros((len(targets), len(x)), dtype=np.float64)

--- a/lpf/objectives/objective.py
+++ b/lpf/objectives/objective.py
@@ -3,7 +3,7 @@
 class Objective:
     
     def __init__(self, device=None):
-        if not device:
+        if device is None:
             device = "cpu"
         
         self.device = device

--- a/lpf/objectives/perceptualsimilarity.py
+++ b/lpf/objectives/perceptualsimilarity.py
@@ -19,14 +19,14 @@ class EachLearnedPerceptualImagePatchSimilarity(Objective):
 
     def __init__(self, net_type=None, coeff=None, device=None):
 
-        if not coeff:
+        if coeff is None:
             coeff = 1.0
 
         self._coeff = coeff
 
         super().__init__(device=device)
 
-        if not net_type:
+        if net_type is None:
             net_type = 'vgg'
 
         self.model = lpips.LPIPS(net=net_type).to(self.device)
@@ -37,7 +37,7 @@ class EachLearnedPerceptualImagePatchSimilarity(Objective):
 
     def compute(self, x, targets, coeff=None):
 
-        if not coeff:
+        if coeff is None:
             coeff = self._coeff
 
         arr_img = []

--- a/lpf/objectives/ssim.py
+++ b/lpf/objectives/ssim.py
@@ -19,7 +19,7 @@ class EachStructuralSimilarityIndexMeasure(Objective):
 
     def __init__(self, coeff=None, device=None):
 
-        if not coeff:
+        if coeff is None:
             coeff = 1.0
 
         self._coeff = coeff
@@ -30,7 +30,7 @@ class EachStructuralSimilarityIndexMeasure(Objective):
 
     def compute(self, x, targets, coeff=None):
 
-        if not coeff:
+        if coeff is None:
             coeff = self._coeff
 
         x = self.to_tensor(x).to(self.device)

--- a/lpf/objectives/vggperceptualloss.py
+++ b/lpf/objectives/vggperceptualloss.py
@@ -50,11 +50,11 @@ class Vgg16PerceptualLoss(torch.nn.Module):
             input = self.transform(input, mode='bilinear', size=(224, 224), align_corners=False)
             target = self.transform(target, mode='bilinear', size=(224, 224), align_corners=False)
 
-        if not feature_layers:
+        if feature_layers is None:
             # feature_layers = [0, 1, 2, 3]
             feature_layers = [2]
 
-        if not style_layers:
+        if style_layers is None:
             style_layers = [0, 1, 2, 3]
 
         loss = torch.zeros((len(input))).to(device=input.device)
@@ -81,7 +81,7 @@ class EachVgg16PerceptualLoss(Objective):
 
     def __init__(self, coeff=None, device=None):
 
-        if not coeff:
+        if coeff is None:
             coeff = 1.0
 
         self._coeff = coeff
@@ -92,7 +92,7 @@ class EachVgg16PerceptualLoss(Objective):
 
     def compute(self, x, targets, coeff=None):
 
-        if not coeff:
+        if coeff is None:
             coeff = self._coeff
 
         arr_img = []

--- a/lpf/search/evosearch.py
+++ b/lpf/search/evosearch.py
@@ -118,10 +118,10 @@ class EvoSearch:
 
         str_now = datetime.now().strftime('%Y%m%d-%H%M%S')
         
-        if not generation:
+        if generation is None:
             str_gen = ""
         else:
-            if not max_generation:
+            if max_generation is None:
                 max_generation = 1000000
                 
             fstr_gen = "gen-%0{}d_".format(int(np.ceil(np.log10(max_generation)))+1)

--- a/lpf/solvers/solver.py
+++ b/lpf/solvers/solver.py
@@ -38,7 +38,7 @@ class Solver:
 
     @property
     def trj_y(self):
-        return self._model.trj_y
+        return self._trj_y
 
     def solve(self,
               model=None,
@@ -58,25 +58,25 @@ class Solver:
 
         t_total_beg = time.time()
 
-        if not model:
-            if not self._model:
+        if model is None:
+            if self._model is None:
                 raise ValueError("model should be defined.")
             model = self._model
 
-        if not dt:
-            if not self._dt:
+        if dt is None:
+            if self._dt is None:
                 self._dt = dt = 0.01
             dt = self._dt
 
-        if not rtol:
-            if self._rtol:
+        if rtol is None:
+            if self._rtol is not None:
                 rtol = self._rtol
 
-        if rtol and rtol < 0:
+        if rtol is not None and rtol < 0:
             raise ValueError("rtol should be greater than 0.")
 
-        if not period_output:
-            if self._period_output:
+        if period_output is None:
+            if self._period_output is not None:
                 period_output = self._period_output
 
         if period_output is not None and period_output < 1:
@@ -100,7 +100,7 @@ class Solver:
             dict_solver["dt"] = dt
             dict_solver["n_iters"] = n_iters
 
-            if rtol:
+            if rtol is not None:
                 dict_solver["rtol"] = rtol
 
             for i in range(batch_size):
@@ -139,10 +139,10 @@ class Solver:
                 = "states_%0{}d".format(int(np.floor(np.log10(n_iters))) + 1)
 
 
-        if not iter_end:
-            
-            if not n_iters:
-                if not self._n_iters:
+        if iter_end is None:
+
+            if n_iters is None:
+                if self._n_iters is None:
                     raise ValueError("n_iters should be defined.")
                 n_iters = self._n_iters
                 
@@ -180,26 +180,28 @@ class Solver:
                 delta_y = self.step(model, t, dt, model.y_mesh)
                 model.y_mesh = model.y_mesh + delta_y
 
-            if not period_output:
+            if period_output is None:
                 pass
             elif i == iter_begin or (i + 1) % period_output == 0:
                 if get_trj:
                     self._trj_y[ix_trj, ...] = model.y_mesh
                     ix_trj += 1
 
-                if dpath_morph:
+                if dpath_morph or dpath_pattern:
                     for j in range(batch_size):
-                        fpath_morph = pjoin(dpath_morph,
-                                               dname_model % (j + 1),
-                                               fstr_fname_morph % (i + 1))
-
-                        fpath_pattern = None
-                        if dpath_pattern:
-                            fpath_pattern = pjoin(dpath_pattern,
+                        fpath_morph_j = None
+                        if dpath_morph:
+                            fpath_morph_j = pjoin(dpath_morph,
                                                   dname_model % (j + 1),
-                                                  fstr_fname_pattern % (i + 1))
+                                                  fstr_fname_morph % (i + 1))
 
-                        model.save_image(j, fpath_morph, fpath_pattern)
+                        fpath_pattern_j = None
+                        if dpath_pattern:
+                            fpath_pattern_j = pjoin(dpath_pattern,
+                                                    dname_model % (j + 1),
+                                                    fstr_fname_pattern % (i + 1))
+
+                        model.save_image(j, fpath_morph_j, fpath_pattern_j)
 
                 if dpath_states:
                     for j in range(batch_size):
@@ -214,7 +216,7 @@ class Solver:
                     t_beg = time.time()
             # end of if
 
-            if rtol and model.is_early_stopping(rtol):
+            if rtol is not None and model.is_early_stopping(rtol):
                 break
             # end of if
 
@@ -239,7 +241,7 @@ class Solver:
         n2v["dt"] = self._dt
         n2v["n_iters"] = self._n_iters
 
-        if self._rtol:
+        if self._rtol is not None:
             n2v["rtol"] = self._rtol
 
         return n2v

--- a/lpf/utils/validation.py
+++ b/lpf/utils/validation.py
@@ -9,8 +9,8 @@ def is_param_invalid(params):
 
 
 def is_state_invalid(arr_u, arr_v):
-    abs_u = np.abs(arr_u.astype(np.float16))
-    abs_v = np.abs(arr_v.astype(np.float16))
+    abs_u = np.abs(arr_u.astype(np.float32))
+    abs_v = np.abs(arr_v.astype(np.float32))
     return (arr_u < 0).any() or (arr_v < 0).any() \
            or np.isnan(np.min(abs_u)) or np.isnan(np.min(abs_v)) \
            or np.isinf(np.max(abs_u)) or np.isinf(np.max(abs_v))

--- a/tests/test_semantic_bugs.py
+++ b/tests/test_semantic_bugs.py
@@ -1,0 +1,332 @@
+"""Tests for P1 semantic bug fixes (issue 2-1 through 2-6)."""
+
+import pytest
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# 2-1: `if not x:` → `if x is None:` — falsy values should not be replaced
+# ---------------------------------------------------------------------------
+
+class TestNotXPattern:
+    """Ensure that valid falsy values (0, 0.0, etc.) are preserved."""
+
+    def test_twocomponentmodel_width_zero_not_overridden(self):
+        """Width=0 should NOT be silently replaced with 128."""
+        from lpf.models import LiawModel
+        from lpf.initializers import LiawInitializer
+
+        init_pts = np.array([[[16, 16]]], dtype=np.uint32)
+        init_states = np.array([[0.5, 0.5]], dtype=np.float32)
+        initializer = LiawInitializer(init_states=init_states, init_pts=init_pts)
+        params = np.array([[1e-3, 1e-2, 1.0, 1.0, 0.01, 0.01, 0.01, 0.01]],
+                          dtype=np.float32)
+
+        # Explicitly set width=0 — should be stored as 0, not silently become 128
+        model = LiawModel(
+            initializer=initializer,
+            params=params,
+            width=0,
+            height=32,
+            dx=0.1,
+            device="cpu",
+        )
+        assert model._width == 0, \
+            "width=0 should be preserved, not silently replaced with default"
+
+    def test_twocomponentmodel_dx_zero_not_overridden(self):
+        """dx=0 should NOT be silently replaced with 0.1."""
+        from lpf.models import LiawModel
+        from lpf.initializers import LiawInitializer
+
+        init_pts = np.array([[[16, 16]]], dtype=np.uint32)
+        init_states = np.array([[0.5, 0.5]], dtype=np.float32)
+        initializer = LiawInitializer(init_states=init_states, init_pts=init_pts)
+        params = np.array([[1e-3, 1e-2, 1.0, 1.0, 0.01, 0.01, 0.01, 0.01]],
+                          dtype=np.float32)
+
+        # dx=0 is physically nonsensical but should NOT be silently overridden
+        model = LiawModel(
+            initializer=initializer,
+            params=params,
+            width=32,
+            height=32,
+            dx=0,
+            device="cpu",
+        )
+        assert model._dx == 0, \
+            "dx=0 should be preserved, not silently replaced with default 0.1"
+
+    def test_objective_coeff_zero_preserved(self):
+        """coeff=0.0 should be stored as-is, not replaced by default."""
+        from lpf.objectives.mse import EachMeanSquareError
+
+        obj = EachMeanSquareError(coeff=0.0)
+        assert obj._coeff == 0.0, \
+            "coeff=0.0 should be preserved, not replaced by default"
+
+    def test_objective_coeff_zero_used_in_compute(self):
+        """When coeff=0.0 is passed to compute(), it should be respected."""
+        from lpf.objectives.mse import EachMeanSquareError
+
+        obj = EachMeanSquareError(coeff=1.0)
+        img1 = np.zeros((10, 10, 3), dtype=np.uint8)
+        img2 = np.ones((10, 10, 3), dtype=np.uint8) * 255
+
+        result = obj.compute([img1], [img2], coeff=0.0)
+        assert np.allclose(result, 0.0), \
+            "coeff=0.0 in compute() should zero out the result"
+
+    def test_solver_dt_zero_not_overridden(self):
+        """dt=0.0 should NOT be silently replaced with 0.01."""
+        from lpf.solvers.solver import Solver
+
+        solver = Solver(dt=0.0)
+        assert solver._dt == 0.0, \
+            "dt=0.0 should be preserved, not silently replaced"
+
+    def test_evosearch_generation_zero_preserved(self):
+        """generation=0 should produce a formatted string, not empty string."""
+        # We can't easily instantiate EvoSearch (needs model etc.),
+        # so we test the generation formatting logic directly.
+        generation = 0
+        max_generation = 100
+
+        # This mirrors the fixed logic in evosearch.py:save()
+        if generation is None:
+            str_gen = ""
+        else:
+            if max_generation is None:
+                max_generation = 1000000
+            fstr_gen = "gen-%0{}d_".format(int(np.ceil(np.log10(max_generation))) + 1)
+            str_gen = fstr_gen % (int(generation))
+
+        assert str_gen != "", \
+            "generation=0 should produce a formatted string, not empty string"
+        assert "gen-" in str_gen
+
+
+# ---------------------------------------------------------------------------
+# 2-2: `to_dict()` skips valid 0 values
+# ---------------------------------------------------------------------------
+
+class TestToDictZeroValues:
+    """Ensure to_dict() includes index=0, generation=0, fitness=0.0."""
+
+    def test_to_dict_includes_index_zero(self, liaw_model):
+        """index=0 should appear in the output dict."""
+        d = liaw_model.to_dict(index=0)
+        assert "index" in d, "index=0 should be included in to_dict() output"
+        assert d["index"] == 0
+
+    def test_to_dict_includes_generation_zero(self, liaw_model):
+        """generation=0 should appear in the output dict."""
+        d = liaw_model.to_dict(index=0, generation=0)
+        assert "generation" in d, \
+            "generation=0 should be included in to_dict() output"
+        assert d["generation"] == 0
+
+    def test_to_dict_includes_fitness_zero(self, liaw_model):
+        """fitness=0.0 should appear in the output dict."""
+        d = liaw_model.to_dict(index=0, fitness=0.0)
+        assert "fitness" in d, \
+            "fitness=0.0 should be included in to_dict() output"
+        assert d["fitness"] == 0.0
+
+    def test_to_dict_excludes_none_values(self, liaw_model):
+        """None values should still be excluded."""
+        d = liaw_model.to_dict(index=0, generation=None, fitness=None)
+        assert "generation" not in d
+        assert "fitness" not in d
+
+
+# ---------------------------------------------------------------------------
+# 2-3: float16 casting causes false positives in is_state_invalid
+# ---------------------------------------------------------------------------
+
+class TestFloat16Casting:
+    """Ensure valid float32 values > 65504 are not falsely flagged as invalid."""
+
+    def test_model_is_state_invalid_large_valid_value(self, liaw_model):
+        """Values in (65504, inf) should be valid under float32 checking."""
+        # float16 max is 65504. Values > 65504 would overflow to inf in float16.
+        val = 70000.0  # Valid in float32, overflow in float16
+        liaw_model._u[0, :, :] = val
+        liaw_model._v[0, :, :] = 0.1
+
+        is_invalid = liaw_model.is_state_invalid(0)
+        assert not is_invalid, \
+            "Value 70000.0 is valid in float32; should not be flagged as invalid"
+
+    def test_validation_util_large_valid_value(self):
+        """Standalone validation.is_state_invalid should also handle large float32."""
+        from lpf.utils.validation import is_state_invalid
+
+        arr_u = np.full((10, 10), 70000.0, dtype=np.float32)
+        arr_v = np.full((10, 10), 0.1, dtype=np.float32)
+
+        assert not is_state_invalid(arr_u, arr_v), \
+            "70000.0 is valid in float32; should not be flagged invalid"
+
+    def test_actual_invalid_values_still_detected(self, liaw_model):
+        """Actually invalid values (negative, NaN, Inf) should still be detected."""
+        # NaN
+        liaw_model._u[0, :, :] = float('nan')
+        liaw_model._v[0, :, :] = 0.1
+        assert liaw_model.is_state_invalid(0), "NaN should be detected as invalid"
+
+        # Negative
+        liaw_model._u[0, :, :] = -1.0
+        liaw_model._v[0, :, :] = 0.1
+        assert liaw_model.is_state_invalid(0), "Negative should be detected as invalid"
+
+        # Inf
+        liaw_model._u[0, :, :] = float('inf')
+        liaw_model._v[0, :, :] = 0.1
+        assert liaw_model.is_state_invalid(0), "Inf should be detected as invalid"
+
+
+# ---------------------------------------------------------------------------
+# 2-4: TorchModule.repeat() semantic mismatch with NumPy
+# ---------------------------------------------------------------------------
+
+class TestTorchRepeatSemantics:
+    """TorchModule.repeat() should match NumPy's np.repeat() behavior."""
+
+    @pytest.fixture
+    def torch_module(self):
+        try:
+            from lpf.array.module import TorchModule
+            return TorchModule("cpu", 0)
+        except ImportError:
+            pytest.skip("PyTorch not available")
+
+    def test_repeat_no_axis_matches_numpy(self, torch_module):
+        """Without axis, repeat should do element-wise repetition like NumPy."""
+        import torch
+
+        np_arr = np.array([1, 2, 3])
+        torch_arr = torch.tensor([1, 2, 3])
+
+        np_result = np.repeat(np_arr, 2)
+        torch_result = torch_module.repeat(torch_arr, 2).numpy()
+
+        np.testing.assert_array_equal(
+            np_result, torch_result,
+            err_msg="TorchModule.repeat(axis=None) should match NumPy semantics: "
+                    "[1,1,2,2,3,3] not [1,2,3,1,2,3]"
+        )
+
+    def test_repeat_with_axis_matches_numpy(self, torch_module):
+        """With axis specified, repeat should match NumPy behavior."""
+        import torch
+
+        np_arr = np.array([[1, 2], [3, 4]])
+        torch_arr = torch.tensor([[1, 2], [3, 4]])
+
+        np_result = np.repeat(np_arr, 2, axis=0)
+        torch_result = torch_module.repeat(torch_arr, 2, axis=0).numpy()
+
+        np.testing.assert_array_equal(np_result, torch_result)
+
+    def test_repeat_2d_no_axis_matches_numpy(self, torch_module):
+        """2D array without axis: NumPy flattens then repeats."""
+        import torch
+
+        np_arr = np.array([[1, 2], [3, 4]])
+        torch_arr = torch.tensor([[1, 2], [3, 4]])
+
+        np_result = np.repeat(np_arr, 3)
+        torch_result = torch_module.repeat(torch_arr, 3).numpy()
+
+        np.testing.assert_array_equal(
+            np_result, torch_result,
+            err_msg="2D repeat without axis should flatten then repeat elements"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2-5: solver.trj_y property reads wrong location
+# ---------------------------------------------------------------------------
+
+class TestSolverTrjY:
+    """solver.trj_y should return self._trj_y, not self._model.trj_y."""
+
+    def test_trj_y_returns_solver_data(self, liaw_model):
+        """After solve with get_trj=True, trj_y should return trajectory data."""
+        from lpf.solvers import EulerSolver
+
+        solver = EulerSolver(model=liaw_model)
+        trj = solver.solve(
+            model=liaw_model,
+            dt=0.01,
+            n_iters=10,
+            period_output=5,
+            get_trj=True,
+        )
+
+        assert trj is not None, "solve() with get_trj=True should return trajectory"
+
+        # The property should return the same object
+        assert solver.trj_y is trj, \
+            "solver.trj_y should return self._trj_y (the trajectory data)"
+
+    def test_trj_y_shape(self, liaw_model):
+        """Trajectory should have shape (n_time_points, *model.shape_grid)."""
+        from lpf.solvers import EulerSolver
+
+        n_iters = 20
+        period_output = 5
+        solver = EulerSolver(model=liaw_model)
+        solver.solve(
+            model=liaw_model,
+            dt=0.01,
+            n_iters=n_iters,
+            period_output=period_output,
+            get_trj=True,
+        )
+
+        # n_time_points = n_iters // period_output + 1
+        expected_time_points = n_iters // period_output + 1
+        assert solver.trj_y.shape[0] == expected_time_points
+
+
+# ---------------------------------------------------------------------------
+# 2-6: Pattern saving should work independently of morph saving
+# ---------------------------------------------------------------------------
+
+class TestPatternSavingIndependent:
+    """Pattern saving should not be nested inside morph saving."""
+
+    def test_save_image_with_pattern_only(self, liaw_model, tmp_path):
+        """save_image should work with fpath_pattern only (no fpath_morph)."""
+        fpath_pattern = str(tmp_path / "test_pattern.png")
+
+        # Should not raise when fpath_morph is None
+        liaw_model.save_image(index=0, fpath_morph=None, fpath_pattern=fpath_pattern)
+
+        import os
+        assert os.path.exists(fpath_pattern), \
+            "Pattern should be saved even when fpath_morph is None"
+
+    def test_save_image_with_morph_only(self, liaw_model, tmp_path):
+        """save_image should work with fpath_morph only (no fpath_pattern)."""
+        fpath_morph = str(tmp_path / "test_morph.png")
+
+        liaw_model.save_image(index=0, fpath_morph=fpath_morph, fpath_pattern=None)
+
+        import os
+        assert os.path.exists(fpath_morph), \
+            "Morph should be saved when fpath_morph is provided"
+
+    def test_save_image_with_both(self, liaw_model, tmp_path):
+        """save_image should work with both morph and pattern paths."""
+        fpath_morph = str(tmp_path / "test_morph.png")
+        fpath_pattern = str(tmp_path / "test_pattern.png")
+
+        liaw_model.save_image(
+            index=0, fpath_morph=fpath_morph, fpath_pattern=fpath_pattern)
+
+        import os
+        assert os.path.exists(fpath_morph)
+        assert os.path.exists(fpath_pattern)


### PR DESCRIPTION
## Summary
- Replace `if not x:` with `if x is None:` across 12 files (40+ locations): fixes valid falsy values like `coeff=0.0`, `dt=0.0`, `generation=0`, `index=0` being silently overwritten with defaults
- Fix `to_dict()` omitting `index=0`, `generation=0`, `fitness=0.0` from output
- Change float16 casting to float32 in `is_state_invalid()` to prevent false positives for valid values above 65504
- Fix `TorchModule.repeat(axis=None)` to match NumPy semantics (element-wise repetition instead of tiling)
- Fix `solver.trj_y` property to return `self._trj_y` instead of `self._model.trj_y`
- Decouple pattern saving from morph saving block so each can be saved independently

## Test plan
- [x] Add 21 regression tests (`tests/test_semantic_bugs.py`)
- [x] All tests pass (69 passed, 5 skipped)
- [x] Trace all call paths to confirm no existing behavior is broken